### PR TITLE
Updated extension to fit phpBB Modders branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
-# Banlist
+# Ban List
+
+Adds a list of banned users to your board for others to view.
+
+## History
+
+The extension is a fork of [amxx-bg/banlist](https://github.com/amxx-bg/banlist) and updated for phpBB 3.3 forums.
 
 ## Installation
 
-Copy the extension to phpBB/ext/evilsystem/banlist
-
-Go to "ACP" > "Customise" > "Extensions" and enable the "Banlist" extension.
+1. Copy the extension package into `ext/phpbbmodders/banlist`.
+2. Log into the ACP and go to the customise tab to enable this extension.
+3. Set the user permissions accordingly.
 
 ## License
 
-[GPLv2](license.txt)
+[GPL v2](license.txt)

--- a/acp/banlist_info.php
+++ b/acp/banlist_info.php
@@ -8,7 +8,7 @@
 *
 */
 
-namespace evilsystem\banlist\acp;
+namespace phpbbmodders\banlist\acp;
 
 /**
 * @ignore
@@ -23,10 +23,10 @@ class banlist_info
 	function module()
 	{
 		return array(
-			'filename'	=> '\evilsystem\banlist\banlist_module',
+			'filename'	=> '\phpbbmodders\banlist\banlist_module',
 			'title'		=> 'BL_ACP',
 			'modes'		=> array(
-				'banlist_config' => array('title' => 'BL_CONFIG', 'auth' => 'ext_evilsystem/banlist && acl_a_board', 'cat' => array('BL_ACP')),
+				'banlist_config' => array('title' => 'BL_CONFIG', 'auth' => 'ext_phpbbmodders/banlist && acl_a_board', 'cat' => array('BL_ACP')),
 			),
 		);
 	}

--- a/acp/banlist_module.php
+++ b/acp/banlist_module.php
@@ -8,7 +8,7 @@
 *
 */
 
-namespace evilsystem\banlist\acp;
+namespace phpbbmodders\banlist\acp;
 
 /**
 * @ignore

--- a/composer.json
+++ b/composer.json
@@ -1,26 +1,37 @@
 {
-    "name": "evilsystem/banlist",
+    "name": "phpbbmodders/banlist",
     "type": "phpbb-extension",
-    "description": "Create a list of banned users of the forum",
-    "homepage": "https://amxx-bg.info",
-    "version": "1.0.5",
-    "time": "2019-07-07",
+    "description": "Adds a list of banned users to your board for others to view.",
+    "version": "1.0.0",
     "license": "GPL-2.0-only",
     "authors": [
+        {
+            "name": "phpBBModders",
+            "email": "board@phpbbmodders.com",
+            "homepage": "https://www.phpbbmodders.com/",
+            "role": "Lead Developer"
+        },
+        {
+            "name": "danieltj",
+            "homepage": "https://www.phpbbmodders.com/community/memberlist.php?mode=viewprofile&u=63",
+            "role": "Contributor"
+        },
         {
             "name": "Evil",
             "email": "inkyzfx@gmail.com",
             "homepage": "http://github.com/stfkolev",
-            "role": "Developer"
+            "role": "Developer of original extension."
         }
     ],
     "require": {
-        "php": ">=5.4"
+        "php": ">=7.0",
+        "composer/installers": "~1.0.0",
+        "phpbb/phpbb": ">=3.3.0"
     },
     "extra": {
-        "display-name": "Banlist",
+        "display-name": "Ban List",
         "soft-require": {
-            "phpbb/phpbb": ">=3.2.0,<3.3.0@dev"
+            "phpbb/phpbb": ">=3.3.12"
         }
     }
 }

--- a/config/routing.yml
+++ b/config/routing.yml
@@ -1,4 +1,4 @@
-evilsystem_banlist_main_controller:
+phpbbmodders_banlist_main_controller:
   path: /banlist
-  defaults: { _controller: evilsystem.banlist.controller.main:main }
+  defaults: { _controller: phpbbmodders.banlist.controller.main:main }
 

--- a/config/services.yml
+++ b/config/services.yml
@@ -1,6 +1,6 @@
 services:
-  evilsystem.banlist.controller.main:
-    class: evilsystem\banlist\controller\main_controller
+  phpbbmodders.banlist.controller.main:
+    class: phpbbmodders\banlist\controller\main_controller
     arguments:
       - "@request"
       - "@config"
@@ -14,10 +14,10 @@ services:
       - "%core.php_ext%"
       - "%core.table_prefix%"
   
-  evilsystem.banlist.main_listener:
-    class: evilsystem\banlist\event\main_listener
+  phpbbmodders.banlist.main_listener:
+    class: phpbbmodders\banlist\event\main_listener
     arguments:
-      - "@evilsystem.banlist.controller.main"
+      - "@phpbbmodders.banlist.controller.main"
       - "@config"
       - "@request"
       - "@dbal.conn"

--- a/controller/main_controller.php
+++ b/controller/main_controller.php
@@ -1,13 +1,12 @@
 <?php
-/**
-*
-* @package Banlist
-* @copyright (c) 2019 Evil
-* @license http://opensource.org/licenses/gpl-2.0.php GNU General Public License v2
-*
-*/
 
-namespace evilsystem\banlist\controller;
+/**
+ * @package Banlist
+ * @copyright (c) 2024 phpBBModders.net
+ * @license https://opensource.org/license/gpl-2-0 GPL v2
+ */
+
+namespace phpbbmodders\banlist\controller;
 
 use Symfony\Component\HttpFoundation\Response;
 

--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -8,7 +8,7 @@
 *
 */
 
-namespace evilsystem\banlist\event;
+namespace phpbbmodders\banlist\event;
 
 /**
 * @ignore
@@ -32,7 +32,7 @@ class main_listener implements EventSubscriberInterface
 	protected $phpbb_root_path;
 	
 	public function __construct(
-		\evilsystem\banlist\controller\main_controller $controller,
+		\phpbbmodders\banlist\controller\main_controller $controller,
 		\phpbb\config\config $config, 
 		\phpbb\request\request $request,
 		\phpbb\db\driver\driver_interface $db, 
@@ -66,7 +66,7 @@ class main_listener implements EventSubscriberInterface
 	public function load_language_on_setup($event) {
 		$lang_set_ext = $event['lang_set_ext'];
 		$lang_set_ext[] = array(
-			'ext_name' => 'evilsystem/banlist',
+			'ext_name' => 'phpbbmodders/banlist',
 			'lang_set' => 'banlist',
 		);
 

--- a/ext.php
+++ b/ext.php
@@ -1,18 +1,9 @@
 <?php
-/**
-*
-* @package Banlist
-* @copyright (c) 2019 Evil
-* @license http://opensource.org/licenses/gpl-2.0.php GNU General Public License v2
-*
-*/
-
-namespace evilsystem\banlist;
 
 /**
-* @ignore
-*/
+ * @package Banlist
+ * @copyright (c) 2024 phpBBModders.net
+ * @license https://opensource.org/license/gpl-2-0 GPL v2
+ */
 
-class ext extends \phpbb\extension\base
-{
-}
+namespace phpbbmodders\banlist;

--- a/migrations/release_1_0_0.php
+++ b/migrations/release_1_0_0.php
@@ -1,13 +1,12 @@
 <?php
-/**
-*
-* @package Banlist
-* @copyright (c) 2019 Evil
-* @license http://opensource.org/licenses/gpl-2.0.php GNU General Public License v2
-*
-*/
 
-namespace evilsystem\banlist\migrations;
+/**
+ * @package Banlist
+ * @copyright (c) 2024 phpBBModders.net
+ * @license https://opensource.org/license/gpl-2-0 GPL v2
+ */
+
+namespace phpbbmodders\banlist\migrations;
 
 /**
 * @ignore
@@ -62,7 +61,7 @@ class release_1_0_0 extends \phpbb\db\migration\migration
 				'acp',
 				'BL_ACP',
 				array(
-					'module_basename'	=> '\evilsystem\banlist\acp\banlist_module',
+					'module_basename'	=> '\phpbbmodders\banlist\acp\banlist_module',
 					'modes'	=> array('banlist_config'),
 				),
 			)),
@@ -80,7 +79,7 @@ class release_1_0_0 extends \phpbb\db\migration\migration
 				'acp',
 				'BL_ACP',
 				array(
-					'module_basename'	=> '\evilsystem\banlist\acp\banlist_module',
+					'module_basename'	=> '\phpbbmodders\banlist\acp\banlist_module',
 					'modes'	=> array('banlist_config'),
 				),
 			)),

--- a/migrations/release_1_0_1.php
+++ b/migrations/release_1_0_1.php
@@ -1,13 +1,12 @@
 <?php
-/**
-*
-* @package Banlist
-* @copyright (c) 2019 Evil
-* @license http://opensource.org/licenses/gpl-2.0.php GNU General Public License v2
-*
-*/
 
-namespace evilsystem\banlist\migrations;
+/**
+ * @package Banlist
+ * @copyright (c) 2024 phpBBModders.net
+ * @license https://opensource.org/license/gpl-2-0 GPL v2
+ */
+
+namespace phpbbmodders\banlist\migrations;
 
 /**
 * @ignore
@@ -25,7 +24,7 @@ class release_1_0_1 extends \phpbb\db\migration\migration
 	}
 static public function depends_on()
 	{
-		return array('\evilsystem\banlist\migrations\release_1_0_0');
+		return array('\phpbbmodders\banlist\migrations\release_1_0_0');
 	}
 
 

--- a/migrations/release_1_0_2.php
+++ b/migrations/release_1_0_2.php
@@ -1,13 +1,12 @@
 <?php
-/**
-*
-* @package Banlist
-* @copyright (c) 2019 Evil
-* @license http://opensource.org/licenses/gpl-2.0.php GNU General Public License v2
-*
-*/
 
-namespace evilsystem\banlist\migrations;
+/**
+ * @package Banlist
+ * @copyright (c) 2024 phpBBModders.net
+ * @license https://opensource.org/license/gpl-2-0 GPL v2
+ */
+
+namespace phpbbmodders\banlist\migrations;
 
 /**
 * @ignore
@@ -25,7 +24,7 @@ class release_1_0_2 extends \phpbb\db\migration\migration
 	}
 static public function depends_on()
 	{
-		return array('\evilsystem\banlist\migrations\release_1_0_1');
+		return array('\phpbbmodders\banlist\migrations\release_1_0_1');
 	}
 
 public function update_schema()

--- a/migrations/release_1_0_3.php
+++ b/migrations/release_1_0_3.php
@@ -1,13 +1,12 @@
 <?php
-/**
-*
-* @package Banlist
-* @copyright (c) 2019 Evil
-* @license http://opensource.org/licenses/gpl-2.0.php GNU General Public License v2
-*
-*/
 
-namespace evilsystem\banlist\migrations;
+/**
+ * @package Banlist
+ * @copyright (c) 2024 phpBBModders.net
+ * @license https://opensource.org/license/gpl-2-0 GPL v2
+ */
+
+namespace phpbbmodders\banlist\migrations;
 
 /**
 * @ignore
@@ -25,7 +24,7 @@ class release_1_0_3 extends \phpbb\db\migration\migration
 	}
 static public function depends_on()
 	{
-		return array('\evilsystem\banlist\migrations\release_1_0_2');
+		return array('\phpbbmodders\banlist\migrations\release_1_0_2');
 	}
 
 	

--- a/migrations/release_1_0_4.php
+++ b/migrations/release_1_0_4.php
@@ -1,13 +1,12 @@
 <?php
-/**
-*
-* @package Banlist
-* @copyright (c) 2019 Evil
-* @license http://opensource.org/licenses/gpl-2.0.php GNU General Public License v2
-*
-*/
 
-namespace evilsystem\banlist\migrations;
+/**
+ * @package Banlist
+ * @copyright (c) 2024 phpBBModders.net
+ * @license https://opensource.org/license/gpl-2-0 GPL v2
+ */
+
+namespace phpbbmodders\banlist\migrations;
 
 /**
 * @ignore
@@ -25,7 +24,7 @@ class release_1_0_4 extends \phpbb\db\migration\migration
 	}
 static public function depends_on()
 	{
-		return array('\evilsystem\banlist\migrations\release_1_0_3');
+		return array('\phpbbmodders\banlist\migrations\release_1_0_3');
 	}
 
 	

--- a/migrations/release_1_0_5.php
+++ b/migrations/release_1_0_5.php
@@ -1,13 +1,12 @@
 <?php
-/**
-*
-* @package Banlist
-* @copyright (c) 2019 Evil
-* @license http://opensource.org/licenses/gpl-2.0.php GNU General Public License v2
-*
-*/
 
-namespace evilsystem\banlist\migrations;
+/**
+ * @package Banlist
+ * @copyright (c) 2024 phpBBModders.net
+ * @license https://opensource.org/license/gpl-2-0 GPL v2
+ */
+
+namespace phpbbmodders\banlist\migrations;
 
 /**
 * @ignore
@@ -25,7 +24,7 @@ class release_1_0_5 extends \phpbb\db\migration\migration
 	}
 static public function depends_on()
 	{
-		return array('\evilsystem\banlist\migrations\release_1_0_4');
+		return array('\phpbbmodders\banlist\migrations\release_1_0_4');
 	}
 
 	

--- a/styles/prosilver/template/event/overall_header_head_append.html
+++ b/styles/prosilver/template/event/overall_header_head_append.html
@@ -1,1 +1,1 @@
-<!-- INCLUDECSS {T_THEME_CSS}ext/evilsystem/banlist/styles/prosilver/theme/banlist.css -->
+<!-- INCLUDECSS {T_THEME_CSS}ext/phpbbmodders/banlist/styles/prosilver/theme/banlist.css -->


### PR DESCRIPTION
The original extension required the user to place the extension into `ext/evilsystem/banlist` and had the original authors branding and whatnot.

I've updated the extension branding as such so it's now a 'phpBB Modders' extension. I've not really touched anything else under the hood though but improve a bit of the code quality in a couple places etc...